### PR TITLE
Add void parameter to make Swift 4 happy

### DIFF
--- a/Sources/Browser.swift
+++ b/Sources/Browser.swift
@@ -101,7 +101,7 @@ public class Browser: NSObject, WKNavigationDelegate, WKScriptMessageHandler {
 
     public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         print("didFinishNavigation was called")
-        callNavigationCompletion(result: .success())
+        callNavigationCompletion(result: .success(()))
     }
 
     public func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {


### PR DESCRIPTION
#6  

In Swift 4 [void types](https://stackoverflow.com/questions/45837915/generic-swift-4-enum-with-void-associated-type) need to be passed in to avoid a compiler error.